### PR TITLE
APP: remove & ignore Chrome.apk symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ kvim3/preinstall/preinstall.mk
 kvim3/preinstall/Chrome.apk
 kvim3l/preinstall/Android.mk
 kvim3l/preinstall/preinstall.mk
+kvim3l/preinstall/Chrome.apk
 kvim/preinstall/Android.mk
 kvim/preinstall/preinstall.mk
+kvim/preinstall/Chrome.apk

--- a/kvim/preinstall/Chrome.apk
+++ b/kvim/preinstall/Chrome.apk
@@ -1,1 +1,0 @@
-../../kvim3/preinstall/Chrome.apk

--- a/kvim3l/preinstall/Chrome.apk
+++ b/kvim3l/preinstall/Chrome.apk
@@ -1,1 +1,0 @@
-../../kvim3/preinstall/Chrome.apk


### PR DESCRIPTION
Linked Chrome.apk is already excluded by "kvim3/preinstall/Chrome.apk" from the .gitignore
